### PR TITLE
Use typscript 2 features for type definitions in react starter

### DIFF
--- a/react-starter/package.json
+++ b/react-starter/package.json
@@ -3,23 +3,21 @@
   "version": "0.0.0",
   "description": "",
   "main": "index.js",
-  "scripts": {
-    "postinstall": "typings install"
-  },
   "author": "wfortin & vseguin",
   "license": "MIT",
   "devDependencies": {
+    "@types/react": "^15.0.1",
+    "@types/react-dom": "^0.14.20",
     "gulp": "^3.9.1",
     "gulp-rename": "^1.2.2",
-    "gulp-sass": "^2.3.1",
-    "ts-loader": "^0.8.2",
-    "typescript": "^1.8.10",
-    "typings": "^1.0.4",
-    "webpack": "^1.13.0",
+    "gulp-sass": "^3.1.0",
+    "ts-loader": "^2.0.0",
+    "typescript": "^2.1.5",
+    "webpack": "^1.14.0",
     "webpack-stream": "^3.2.0"
   },
   "dependencies": {
-    "react": "^15.0.2",
-    "react-dom": "^15.0.2"
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2"
   }
 }

--- a/react-starter/tsconfig.json
+++ b/react-starter/tsconfig.json
@@ -7,9 +7,6 @@
     "jsx": "react",
     "outDir": "dist"
   },
-  "files": [
-    "./typings/index.d.ts"
-  ],
   "exclude": [
     "node_modules"
   ]

--- a/react-starter/typings.json
+++ b/react-starter/typings.json
@@ -1,9 +1,0 @@
-{
-  "name": "glo-3112-react-starter",
-  "version": false,
-  "dependencies": {},
-  "globalDependencies": {
-    "react": "registry:dt/react#0.14.0+20160423065914",
-    "react-dom": "registry:dt/react-dom#0.14.0+20160412154040"
-  }
-}


### PR DESCRIPTION
Easier managing of typescript declaration files with typescript 2.0+ and update almost every dependencies in the react-starter-pack.

See [](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md) for informations on getting declarion files with npm.